### PR TITLE
ABX-4549 AccountName apply field length limit

### DIFF
--- a/src/components/EditableText.tsx
+++ b/src/components/EditableText.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 interface EditableProps {
+  hasError?: boolean
   isEditing: boolean
   value: string
   onChangeHandler: React.ChangeEventHandler<HTMLInputElement>
@@ -16,7 +17,7 @@ export class EditableText extends React.Component<EditableProps> {
       <div className={this.controlClasses()}>
         <input
           style={{ textTransform: 'initial' }}
-          className={this.inputClasses() + (isLarge ? ' is-large' : '')}
+          className={this.inputClasses() + (isLarge ? ' is-large' : '') + (this.props.hasError ? ' is-danger' : '')}
           value={this.props.value}
           onChange={this.props.onChangeHandler}
           onBlur={this.onBlur}

--- a/src/containers/__tests__/AccountPanel.test.tsx
+++ b/src/containers/__tests__/AccountPanel.test.tsx
@@ -1,64 +1,84 @@
-import { AccountPanelComponent } from '@containers/AccountPanel'
-import { NotificationType } from '@types'
 import { shallow } from 'enzyme'
 import { Keypair } from 'js-kinesis-sdk'
 import * as React from 'react'
+
+import { AccountPanelComponent } from '@containers/AccountPanel'
 import '../../setupTests'
 
 describe.only('AccountPanel', () => {
+  const existingName = 'b'
   const props = {
     activeAccount: {
-      name: 'b',
-      keypair: Keypair.random()
+      name: existingName,
+      keypair: Keypair.random(),
     },
     accountNames: ['a', 'b', 'c'],
   }
 
-  it('throws an error action if the name already exists on another account', () => {
-    const showNotification = jest.fn()
+  it('calls updateAccountName after editing if input is valid', () => {
     const updateAccountName = jest.fn()
-    const localProps = { ...props, showNotification, updateAccountName }
+    const localProps = { ...props, updateAccountName }
 
     const wrapper = shallow(<AccountPanelComponent {...localProps} />)
     const instance = wrapper.instance() as AccountPanelComponent
 
-    instance.onChange({target: {value: 'c'}})
-    instance.onStopEditing()
+    const input = 'ok'
 
-    expect(showNotification).toHaveBeenCalled()
+    instance.handleChange({ target: { value: input } })
+    instance.handleStopEditing()
+    const { hasError, errorText } = instance.state
+
+    expect(hasError).toBe(false)
+    expect(errorText).toEqual('')
+    expect(updateAccountName).toHaveBeenCalledWith({ existingName, newName: input })
+  })
+
+  it('shows error text if the account name already exists', () => {
+    const updateAccountName = jest.fn()
+    const localProps = { ...props, updateAccountName }
+
+    const wrapper = shallow(<AccountPanelComponent {...localProps} />)
+    const instance = wrapper.instance() as AccountPanelComponent
+
+    const input = 'c'
+
+    instance.handleChange({ target: { value: input } })
+    instance.handleStopEditing()
+    const { hasError, errorText } = instance.state
+
+    expect(hasError).toBe(true)
+    expect(errorText).toEqual(`Account with name "${input}" already exists`)
     expect(updateAccountName).not.toHaveBeenCalled()
-    expect(showNotification).toBeCalledWith({message: 'Account name must be unique', type: NotificationType.error})
   })
 
-  it('nothing is dispatched if the name isnt changed', () => {
-    const showNotification = jest.fn()
+  it('shows error text if the name is over 20 characters', () => {
     const updateAccountName = jest.fn()
-    const localProps = { ...props, showNotification, updateAccountName }
+    const localProps = { ...props, updateAccountName }
 
     const wrapper = shallow(<AccountPanelComponent {...localProps} />)
     const instance = wrapper.instance() as AccountPanelComponent
 
-    instance.onChange({target: {value: 'b'}})
-    instance.onStopEditing()
+    const input = 'itsovertwentycharacters'
 
-    expect(showNotification).not.toHaveBeenCalled()
+    instance.handleChange({ target: { value: input } })
+    const { hasError, errorText } = instance.state
+    instance.handleStopEditing()
+
+    expect(hasError).toBe(true)
+    expect(errorText).toEqual('Maximum name length is 20 characters')
     expect(updateAccountName).not.toHaveBeenCalled()
   })
 
-  it('dispatches a success banner when the account name is updated correctly', () => {
-    const showNotification = jest.fn()
+  it("nothing happens if the name doesn't change", () => {
     const updateAccountName = jest.fn()
-    const localProps = { ...props, showNotification, updateAccountName }
+    const localProps = { ...props, updateAccountName }
 
     const wrapper = shallow(<AccountPanelComponent {...localProps} />)
     const instance = wrapper.instance() as AccountPanelComponent
 
-    instance.onChange({target: {value: 'd'}})
-    instance.onStopEditing()
+    instance.handleChange({ target: { value: existingName } })
+    instance.handleStopEditing()
 
-    expect(showNotification).toHaveBeenCalled()
-    expect(updateAccountName).toHaveBeenCalled()
-    expect(showNotification).toBeCalledWith({message: 'Account name successfully updated', type: NotificationType.success})
+    expect(updateAccountName).not.toHaveBeenCalled()
   })
-
 })

--- a/src/store/epics/__tests__/accounts.test.ts
+++ b/src/store/epics/__tests__/accounts.test.ts
@@ -1,44 +1,21 @@
-import { accountLoadRequest } from '@actions'
-import { loadAccount$ } from '../accounts'
+import { showNotification, updateAccountName } from '@actions'
+import { NotificationType } from '@types'
+import { accountNameUpdate } from '../accounts'
 import { epicTest } from './helpers'
 
 describe('Accounts epic', () => {
-  describe('loadAccount$', () => {
-    const account = 'account'
-    const connection = 'connection'
-    const error = 'error'
-    const publicKey = 'public key'
+  it('accountNameUpdate triggers success notification', async () => {
+    const nameUpdate = { existingName: 'name', newName: 'newName' }
 
-    it('success', async () => {
-      const loadAccount = jest.fn(() => Promise.resolve(account))
-      const getCurrentConnection = jest.fn()
-      const getTransactions = jest.fn(() => Promise.resolve([]))
-
-      await epicTest({
-        epic: loadAccount$,
-        inputActions: [accountLoadRequest(publicKey)],
-        state: {
-          router: { location: { pathname: '/dashboard' } },
-          connections: {},
-        },
-        dependencies: { loadAccount, getCurrentConnection, getTransactions },
-      })
-    })
-
-    it('failure', async () => {
-      const getCurrentConnection = jest.fn(() => connection)
-      const loadAccount = jest.fn(() => Promise.reject(error))
-      const getTransactions = jest.fn(() => Promise.resolve([]))
-
-      await epicTest({
-        epic: loadAccount$,
-        inputActions: [accountLoadRequest(publicKey)],
-        state: {
-          router: { location: { pathname: '/dashboard' } },
-          connections: {},
-        },
-        dependencies: { loadAccount, getCurrentConnection, getTransactions },
-      })
+    await epicTest({
+      epic: accountNameUpdate,
+      expectedActions: [
+        showNotification({
+          type: NotificationType.success,
+          message: 'Account name successfully updated',
+        }),
+      ],
+      inputActions: [updateAccountName(nameUpdate)],
     })
   })
 })

--- a/src/store/epics/notifier.ts
+++ b/src/store/epics/notifier.ts
@@ -1,12 +1,13 @@
-import { clearNotification, showNotification } from '@actions'
-import { RootEpic } from '@store'
-import { timer } from 'rxjs'
-import { delayWhen, filter, map } from 'rxjs/operators'
+import { pipe, timer } from 'rxjs'
+import { filter, map, switchMap } from 'rxjs/operators'
 import { isActionOf } from 'typesafe-actions'
 
-export const clearNotifier$: RootEpic = (action$) =>
-  action$.pipe(
-    filter(isActionOf(showNotification)),
-    delayWhen(({payload}) => timer(payload.displayTime || 5000)),
-    map(clearNotification)
-  )
+import { clearNotification, showNotification } from '@actions'
+import { RootEpic } from '@store'
+
+export const clearNotifier$: RootEpic = pipe(
+  filter(isActionOf(showNotification)),
+  map(({ payload }) => payload.displayTime || 5000),
+  switchMap(timer),
+  map(clearNotification),
+)

--- a/src/store/root-epic.ts
+++ b/src/store/root-epic.ts
@@ -6,6 +6,7 @@ import { decryptWithPassword, encryptWithPassword } from '@services/encryption'
 import { getTransactionErrorMessage, getTransactions, isValidPublicKey } from '@services/kinesis'
 import { createKinesisTransfer, submitSignedTransaction } from '@services/transfer'
 
+import { getActiveAccount, getCurrentConnection, getLoginState } from '@selectors'
 import {
   generateMnemonic,
   getKeypairFromMnemonic,
@@ -14,13 +15,14 @@ import {
 import * as epics from './epics'
 import { RootAction } from './root-action'
 import { RootState } from './root-reducer'
-import { getCurrentConnection } from './selectors'
 
 export const epicDependencies = {
   createKinesisTransfer,
   formAlert,
   generalFailureAlert,
   generalSuccessAlert,
+  getActiveAccount,
+  getLoginState,
   getCurrentConnection,
   getTransactionErrorMessage,
   getTransactions,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,51 +16,24 @@
     "noEmitHelpers": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "lib": [
-      "es2017",
-      "dom"
-    ],
+    "lib": ["es2017", "dom"],
     "target": "es5",
     "jsx": "react",
     "rootDir": "src",
     "baseUrl": "src",
     "paths": {
-      "@services/*": [
-        "services/*"
-      ],
-      "@types": [
-        "types"
-      ],
-      "@helpers/*": [
-        "helpers/*"
-      ],
-      "@components/*": [
-        "components/*"
-      ],
-      "@store": [
-        "store"
-      ],
-      "@actions": [
-        "store/actions"
-      ],
-      "@containers/*": [
-        "containers/*"
-      ],
-      "@selectors": [
-        "store/selectors"
-      ],
-      "@containers": [
-        "containers"
-      ],
-      "@reducers/*": [
-        "store/reducers/*"
-      ],
-      "@images/*": [
-        "images/*"
-      ],
-      "@icons/*": [
-        "icons/*"
-      ]
+      "@services/*": ["services/*"],
+      "@types": ["types"],
+      "@helpers/*": ["helpers/*"],
+      "@components/*": ["components/*"],
+      "@store": ["store"],
+      "@actions": ["store/actions"],
+      "@containers/*": ["containers/*"],
+      "@selectors": ["store/selectors"],
+      "@containers": ["containers"],
+      "@reducers/*": ["store/reducers/*"],
+      "@images/*": ["images/*"],
+      "@icons/*": ["icons/*"]
     }
   },
   "formatCodeOptions": {


### PR DESCRIPTION
AccountPanel

* add hasError prop to editable text to display red border around input
* validate account name change for length and uniqueness
* remove notification callback
* update test

Epics

* update accounts to call notification after account name update
* update notifier to stop odd behaviour on repeated calls
* update wallet to handle bug creating account from seedphrase if
account name already exists