### PR TITLE
ABX-4995 Update Max Transfer

### DIFF
--- a/src/services/kinesis.ts
+++ b/src/services/kinesis.ts
@@ -70,6 +70,20 @@ export async function getFeeInKinesis(
   return String(Number(feeInStroops) / STROOPS_IN_ONE_KINESIS)
 }
 
+export async function getMinBalanceInKinesis(connection: Connection): Promise<number> {
+  const {
+    records: [latestLedger],
+  } = await getServer(connection)
+    .ledgers()
+    .order('desc')
+    .limit(1)
+    .call()
+
+  const { base_reserve_in_stroops: baseReserveInStroops } = latestLedger
+
+  return baseReserveInStroops / STROOPS_IN_ONE_KINESIS
+}
+
 export async function getTransactions(
   connection: Connection,
   accountKey: string,

--- a/src/store/root-epic.ts
+++ b/src/store/root-epic.ts
@@ -5,6 +5,8 @@ import { loadAccount } from '@services/accounts'
 import { sendAnalyticsEvent } from '@services/analytics'
 import { decryptWithPassword, encryptWithPassword } from '@services/encryption'
 import {
+  getFeeInKinesis,
+  getMinBalanceInKinesis,
   getNextTransactionPage,
   getTransactionErrorMessage,
   getTransactions,
@@ -42,6 +44,8 @@ export const epicDependencies = {
   isValidPublicKey,
   sendAnalyticsEvent,
   getNextTransactionPage,
+  getFeeInKinesis,
+  getMinBalanceInKinesis,
 }
 
 export type EpicDependencies = typeof epicDependencies


### PR DESCRIPTION
* update the remaining balance calculation to use switchMap for only taking latest input value
* update insufficient funds calculation to require at least 2 * base reserve (as per network) for now
NB this may need to be more accurate in the future
* move amountCalculations$ dependencies into injected epic dependencies at root-epic