### PR TITLE
Abx 6654 add minimum transfer amount limit

### DIFF
--- a/src/containers/TransferCurrency/TransferPage.tsx
+++ b/src/containers/TransferCurrency/TransferPage.tsx
@@ -174,7 +174,7 @@ export class TransferPagePresentation extends React.Component<Props, State> {
       wallet: { accounts: walletAccounts },
     } = this.props
 
-    const transactionFee = (Number(fee) - BASE_NETWORK_FEE).toFixed(20)
+    const transactionFee = Number(fee) - BASE_NETWORK_FEE
 
     return (
       <div className="columns is-mobile is-centered">

--- a/src/services/kinesis.ts
+++ b/src/services/kinesis.ts
@@ -121,6 +121,16 @@ export async function getMinBalanceInKinesis(
   return minBalance
 }
 
+export async function getBaseReserveInKinesis(connection: Connection) {
+  const server = getServer(connection)
+  const mostRecentLedger = await server
+    .ledgers()
+    .order('desc')
+    .call()
+  const { base_reserve_in_stroops: baseReserveInStroops } = mostRecentLedger.records[0]
+  return Number(baseReserveInStroops) / STROOPS_IN_ONE_KINESIS
+}
+
 export async function getTransactions(
   connection: Connection,
   accountKey: string,

--- a/src/store/actions/transactions.ts
+++ b/src/store/actions/transactions.ts
@@ -25,9 +25,12 @@ export const transactionSuccess = createStandardAction('TRANSACTION_SUBMIT_SUCCE
 export const transactionFailed = createStandardAction('TRANSACTION_SUBMIT_FAILED')<Error>()
 
 export const updateFee = createStandardAction('UPDATE_FEE')<string>()
-export const insufficientFunds = createStandardAction('INSUFFICIENT_FUNDS')<boolean>()
+export const insufficientFunds = createStandardAction('INSUFFICIENT_FUNDS')<string>()
 export const updateRemainingBalance = createStandardAction('UPDATE_REMAINING_BALANCE')<number>()
 export const updateMinimumBalance = createStandardAction('UPDATE_MINIMUM_BALANCE')<number>()
 
 export const publicKeyValidation = createStandardAction('PUBLIC_KEY_VALIDATION')<boolean>()
 export const saveToContact = createAction('SAVE_TO_CONTACT')
+
+export const targetPayeeAccountNotExist = createAction('TARGET_PAYEE_ACCOUNT_NOT_EXIST')
+export const targetPayeeAccountExist = createAction('TARGET_PAYEE_ACCOUNT_EXIST')

--- a/src/store/epics/transfer.ts
+++ b/src/store/epics/transfer.ts
@@ -96,7 +96,7 @@ export const amountCalculations$: RootEpic = (
     withLatestFrom(state$),
     map(([isInsufficientFunds, { transfer: { targetPayeeIsExisted, formData: { amount } } }]) => {
       if (!targetPayeeIsExisted && Number(amount) < 0.02) {
-        return insufficientFunds('Minimum amount to transfer is 0.02')
+        return insufficientFunds('Minimum transfer amount to create account is 0.02')
       }
       if (isInsufficientFunds) {
         return insufficientFunds('Insufficient funds')

--- a/src/store/epics/transfer.ts
+++ b/src/store/epics/transfer.ts
@@ -98,6 +98,7 @@ export const amountCalculations$: RootEpic = (
       ([
         isInsufficientFunds,
         {
+          connections: { currentCurrency },
           transfer: {
             targetPayeeIsExisted,
             formData: { amount, targetPayee },
@@ -105,7 +106,9 @@ export const amountCalculations$: RootEpic = (
         },
       ]) => {
         if (isValidPublicKey(targetPayee) && !targetPayeeIsExisted && Number(amount) < 0.02) {
-          return insufficientFunds('Minimum transfer amount to create account is 0.02')
+          return insufficientFunds(
+            `The transfer amount of this transaction must be at least 0.02 ${currentCurrency}`,
+          )
         }
         if (isInsufficientFunds) {
           return insufficientFunds('Insufficient funds')

--- a/src/store/reducers/transfer.ts
+++ b/src/store/reducers/transfer.ts
@@ -2,6 +2,8 @@ import {
   addContact,
   insufficientFunds,
   publicKeyValidation,
+  targetPayeeAccountExist,
+  targetPayeeAccountNotExist,
   transactionFailed,
   transactionRequest,
   transactionSuccess,
@@ -26,6 +28,7 @@ export interface TransferState {
   readonly formData: TransferRequest
   readonly isTransferring: boolean
   readonly formMeta: FormMeta
+  readonly targetPayeeIsExisted: boolean
 }
 
 const formMeta = combineReducers<FormMeta, RootAction>({
@@ -56,7 +59,11 @@ function handleError(name: keyof FormErrors) {
   return (state = '', action: RootAction) => {
     switch (action.type) {
       case getType(insufficientFunds):
-        return name === 'amount' && action.payload ? 'Insufficient funds' : ''
+        if (name === 'amount') {
+          return action.payload
+        } else {
+          return state
+        }
       case getType(updateTransferForm):
         return name === 'memo' &&
           action.payload.field === 'memo' &&
@@ -91,6 +98,16 @@ export const transfer = combineReducers<TransferState, RootAction>({
       case getType(transactionFailed):
         return false
 
+      default:
+        return state
+    }
+  },
+  targetPayeeIsExisted: (state = false, action) => {
+    switch (action.type) {
+      case getType(targetPayeeAccountNotExist):
+        return false
+      case getType(targetPayeeAccountExist):
+        return true
       default:
         return state
     }

--- a/src/store/reducers/transfer.ts
+++ b/src/store/reducers/transfer.ts
@@ -102,7 +102,7 @@ export const transfer = combineReducers<TransferState, RootAction>({
         return state
     }
   },
-  targetPayeeIsExisted: (state = false, action) => {
+  targetPayeeIsExisted: (state = true, action) => {
     switch (action.type) {
       case getType(targetPayeeAccountNotExist):
         return false

--- a/src/store/root-epic.ts
+++ b/src/store/root-epic.ts
@@ -5,6 +5,7 @@ import { loadAccount } from '@services/accounts'
 import { sendAnalyticsEvent } from '@services/analytics'
 import { decryptWithPassword, encryptWithPassword } from '@services/encryption'
 import {
+  getBaseReserveInKinesis,
   getFeeInKinesis,
   getMinBalanceInKinesis,
   getNextTransactionPage,
@@ -46,6 +47,7 @@ export const epicDependencies = {
   getNextTransactionPage,
   getFeeInKinesis,
   getMinBalanceInKinesis,
+  getBaseReserveInKinesis,
 }
 
 export type EpicDependencies = typeof epicDependencies


### PR DESCRIPTION
## Context
[Failed transaction yet again on 10/24/2019](https://bullioncapital.atlassian.net/browse/ABX-6654)
[StandAlone Wallet: Transaction fee is rounding incorrectly on initial send screen](https://bullioncapital.atlassian.net/browse/ABX-6693)

Client try to send 0.01 to the deposit address but fail and fee was taken from he's account. The reason is the stellar network required `minimum balance 0.02` to create an account. Every time when the deposit go into the KMS, we do `merge account operation` which will get rid of the account from the network. Hence, the next deposit to the same address will be seen as `create account operation`. Then 0.02 is required.

The second issue is rounding issue on display

## Implementation
With this changes, we check the address from the network to see if the account is already existed or not. If not, we will throw an error message to the user if the transfer amount is less than 0.02.